### PR TITLE
LtrSupportModule is missing in application.conf

### DIFF
--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -78,6 +78,7 @@ slick.dbs.default.db.password=""
 
 play.http.parser.maxMemoryBuffer=1024k
 play.modules.enabled += "org.nlp4l.framework.actors.modules.FrameworkModule"
+play.modules.enabled += "org.nlp4l.ltr.support.actors.LtrSupportModule"
 
 #akka {
 #  loggers = ["akka.event.slf4j.Slf4jLogger"]


### PR DESCRIPTION
Hi 

When I launched the new nlp4l and accessed to the top page, threre was a
injection error of "progress-actor". It seems play.modules.ebnaled
setting for ltr is missing in the application.conf.

Thank you
