### PR TITLE
add import feature of query annotation csv data.

### DIFF
--- a/app/assets/javascripts/ltr/support/query.coffee
+++ b/app/assets/javascripts/ltr/support/query.coffee
@@ -34,6 +34,19 @@ $ ->
     $('#uploadform').attr('method', 'POST')
     $('#uploadform').submit()
 
+  $('#importFile').change ->
+    files = $('#importFile')[0].files
+    if (files.length == 1)
+      $('#import').prop('disabled', false)
+    else
+      $('#import').prop('disabled', true)
+
+  $('#import').click ->
+    action = '/ltr/query/' + ltrid + '/import'
+    $('#importform').attr('action', action)
+    $('#importform').attr('method', 'POST')
+    $('#importform').submit()
+
   $('#clear').click ->
     action = '/ltr/query/' + ltrid + '/clear'
     $('#uploadform').attr('action', action)

--- a/app/org/nlp4l/ltr/support/views/query.scala.html
+++ b/app/org/nlp4l/ltr/support/views/query.scala.html
@@ -40,7 +40,7 @@
   <div class="container-fluid">
     <div class="row">
       <form id="uploadform" data-toggle="validator" enctype="multipart/form-data" method="post">
-      <div class="col-md-5">
+      <div class="col-md-4">
           <p class="text-success">@success</p>
           <p class="text-danger">@error</p>
       </div>
@@ -49,7 +49,7 @@
             <input type="file" id="query" name="query">
           </div>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-5">
         <button id="upload-button" type="button" class="btn btn-primary" data-toggle="modal" data-target="#uploadModal" disabled><i class="glyphicon glyphicon-upload"></i> Upload</button>
         <!-- Modal -->
         <div class="modal fade" id="uploadModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
@@ -82,6 +82,32 @@
           </div>
         </div>
 
+        <button id="import-button" type="button" class="btn btn-primary" data-toggle="modal" data-target="#importModal"><i class="glyphicon glyphicon-import"></i> Import</button>
+
+      </div>
+      </form>
+
+      <!-- Modal -->
+      <div class="modal fade" id="importModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-body">
+              <p>
+              <form id="importform" data-toggle="validator" enctype="multipart/form-data" method="post">
+              <p>
+                <strong>Specify query annotation data file. </strong>
+              </p>
+              <div class="form-group">
+                <input type="file" id="importFile" name="importFile">
+              </div>
+              </form>
+              <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+              <button id="import" type="button" class="btn btn-primary" disabled>Import</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
         <!-- Modal -->
         <div class="modal fade" id="clearEachModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
           <div class="modal-dialog" role="document">
@@ -112,8 +138,6 @@
           </div>
         </div>
 
-        </div>
-      </form>
     </div>
 
 

--- a/conf/routes
+++ b/conf/routes
@@ -84,6 +84,7 @@ POST          /ltr/config                                              @org.nlp4
 POST          /ltr/config/$ltrid<[0-9]+>                               @org.nlp4l.ltr.support.controllers.LtrController.saveLtrConfig(ltrid: Int)
 DELETE        /ltr/config/$ltrid<[0-9]+>                               @org.nlp4l.ltr.support.controllers.LtrController.deleteLtrConfig(ltrid: Int)
 POST          /ltr/query/$ltrid<[0-9]+>                                @org.nlp4l.ltr.support.controllers.LtrController.saveQuery(ltrid: Int)
+POST          /ltr/query/$ltrid<[0-9]+>/import                         @org.nlp4l.ltr.support.controllers.LtrController.importQueryAnnotation(ltrid: Int)
 POST          /ltr/query/$ltrid<[0-9]+>/clear                          @org.nlp4l.ltr.support.controllers.LtrController.clearAllAnnotation(ltrid: Int)
 POST          /ltr/query/$ltrid<[0-9]+>/clear/$qid<[0-9]+>             @org.nlp4l.ltr.support.controllers.LtrController.clearAnnotation(ltrid: Int, qid: Int)
 GET           /ltr/query/$ltrid<[0-9]+>/list                           @org.nlp4l.ltr.support.controllers.LtrController.listQuery(ltrid: Int)


### PR DESCRIPTION
Hi
  
I've just added import feature for query annotation csv data.
This feature import query annotation data, which is created externally by using user's click log.

In this version, we simply add csv data into the tables.
Importing with click model (DCM) would be coming soon.

Please take a look.

Thank you
