### PR TITLE
specify charSet as UTF-8 when importing impression log json file.

### DIFF
--- a/app/org/nlp4l/ltr/support/controllers/LtrController.scala
+++ b/app/org/nlp4l/ltr/support/controllers/LtrController.scala
@@ -171,7 +171,7 @@ class LtrController @Inject()(docFeatureDAO: DocFeatureDAO,
       val importType = request.body.dataParts.getOrElse("importType", Seq("QAD")).head
       val importSettings = request.body.dataParts.getOrElse("importSettings", Seq("")).head
       if (importType.equals("ICM") || importType.equals("DCM")) {
-        val source: String = Source.fromFile(temp.getAbsolutePath).getLines.mkString
+        val source: String = Source.fromFile(temp.getAbsolutePath, "UTF-8").getLines.mkString
         val json: JsValue = Json.parse(source)
         val data =  (json \ "data").as[Seq[ImpressionLog]]
         val dcm = true


### PR DESCRIPTION
Hi

There seems to be a bug in the recent commit.
Importing impression log(json) with Japanese chars didn't work,
so I've changed to specify UTF-8 when reading imported file.

Thank you.
